### PR TITLE
Hotfix order create action

### DIFF
--- a/app/controllers/member/orders_controller.rb
+++ b/app/controllers/member/orders_controller.rb
@@ -23,7 +23,7 @@ class Member::OrdersController < ApplicationController
   def create
     if @order = current_member.orders.create(order_params)
       @order.cart_to_order(current_member.cart_items)
-      current_member.ships.create(ship_params) if params[:order][:new_ship?]
+      current_member.ships.create(ship_params) if params[:order][:new_ship]
       redirect_to thanks_members_orders_path
     else
       redirect_to members_cart_items_path

--- a/app/controllers/member/orders_controller.rb
+++ b/app/controllers/member/orders_controller.rb
@@ -21,6 +21,7 @@ class Member::OrdersController < ApplicationController
   end
 
   def create
+    binding.pry
     if @order = current_member.orders.create(order_params)
       @order.cart_to_order(current_member.cart_items)
       current_member.ships.create(ship_params) if params[:order][:new_ship]
@@ -42,7 +43,7 @@ class Member::OrdersController < ApplicationController
       def confirm_params
         params.require(:order).permit(:postal_code, :address, :name,
            :payment_method, :billing_amount, :ship_id, :ship_postal_code,
-           :ship_name, :ship_address, :choice, :new_ship?)
+           :ship_name, :ship_address, :choice, :new_ship)
       end
 
       def order_params

--- a/app/controllers/member/orders_controller.rb
+++ b/app/controllers/member/orders_controller.rb
@@ -21,10 +21,9 @@ class Member::OrdersController < ApplicationController
   end
 
   def create
-    binding.pry
     if @order = current_member.orders.create(order_params)
       @order.cart_to_order(current_member.cart_items)
-      current_member.ships.create(ship_params) if params[:order][:new_ship]
+      ship = current_member.ships.create(ship_params) if params[:order][:new_ship] == "true"
       redirect_to thanks_members_orders_path
     else
       redirect_to members_cart_items_path

--- a/app/controllers/member/orders_controller.rb
+++ b/app/controllers/member/orders_controller.rb
@@ -17,13 +17,13 @@ class Member::OrdersController < ApplicationController
 
   def confirm
     @order = current_member.orders.new(payment_method: params[:order][:payment_method])
-    @order.set_new_order(order_params)
+    @new_ship = @order.set_new_order(confirm_params)
   end
 
   def create
-    binding.pry
     if @order = current_member.orders.create(order_params)
       @order.cart_to_order(current_member.cart_items)
+      current_member.ships.create(ship_params) if params[:order][:new_ship?]
       redirect_to thanks_members_orders_path
     else
       redirect_to members_cart_items_path
@@ -39,10 +39,19 @@ class Member::OrdersController < ApplicationController
         redirect_to members_cart_items_path if params[:id] == "confirm"
       end
 
-      def order_params
+      def confirm_params
         params.require(:order).permit(:postal_code, :address, :name,
            :payment_method, :billing_amount, :ship_id, :ship_postal_code,
            :ship_name, :ship_address, :choice, :new_ship?)
+      end
+
+      def order_params
+        params.require(:order).permit(:postal_code, :address, :name,
+           :payment_method, :billing_amount)
+      end
+
+      def ship_params
+        params.require(:order).permit(:postal_code, :address, :name)
       end
 
 end

--- a/app/controllers/member/orders_controller.rb
+++ b/app/controllers/member/orders_controller.rb
@@ -21,6 +21,7 @@ class Member::OrdersController < ApplicationController
   end
 
   def create
+    binding.pry
     if @order = current_member.orders.create(order_params)
       @order.cart_to_order(current_member.cart_items)
       redirect_to thanks_members_orders_path
@@ -41,7 +42,7 @@ class Member::OrdersController < ApplicationController
       def order_params
         params.require(:order).permit(:postal_code, :address, :name,
            :payment_method, :billing_amount, :ship_id, :ship_postal_code,
-           :ship_name, :ship_address, :choice)
+           :ship_name, :ship_address, :choice, :new_ship?)
       end
 
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -22,18 +22,21 @@ class Order < ApplicationRecord
   end
 
   def set_new_order(params)
+    new_ship = false
     case params[:choice]
       when "0"
         self.set_address(self.member)
       when "1"
         self.set_address(self.member.ships.find(params[:ship_id]))
       when "2"
+        new_ship = true
         ship = self.member.ships.new(postal_code: params[:ship_postal_code],
                                         name: params[:ship_name],
                                         address: params[:ship_address])
           self.set_address(ship)
     end
     self.billing_amount = total_price(self.member.cart_items) + self.postage
+    return new_ship
   end
 
   def cart_to_order(cart_items)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -28,7 +28,7 @@ class Order < ApplicationRecord
       when "1"
         self.set_address(self.member.ships.find(params[:ship_id]))
       when "2"
-        ship = self.member.ships.create(postal_code: params[:ship_postal_code],
+        ship = self.member.ships.new(postal_code: params[:ship_postal_code],
                                         name: params[:ship_name],
                                         address: params[:ship_address])
           self.set_address(ship)

--- a/app/views/member/orders/_confirmation_button.html.erb
+++ b/app/views/member/orders/_confirmation_button.html.erb
@@ -1,4 +1,4 @@
-<!-- recieves order -->
+<!-- recieves order new_ship -->
 
 <%= form_with model: order, url: members_orders_path, local: true do |f| %>
     <%= f.hidden_field :postal_code %>
@@ -6,6 +6,6 @@
     <%= f.hidden_field :name %>
     <%= f.hidden_field :payment_method %>
     <%= f.hidden_field :billing_amount %>
-    <%= f.hidden_field :new_ship?, value: "1" %>
+    <%= f.hidden_field :new_ship?, value: new_ship %>
     <%= f.submit "購入を確定する", class:"btn btn-success center-block" %>
 <% end %>

--- a/app/views/member/orders/_confirmation_button.html.erb
+++ b/app/views/member/orders/_confirmation_button.html.erb
@@ -6,6 +6,6 @@
     <%= f.hidden_field :name %>
     <%= f.hidden_field :payment_method %>
     <%= f.hidden_field :billing_amount %>
-    <%= f.hidden_field :new_ship?, value: new_ship %>
+    <%= f.hidden_field :new_ship, value: new_ship %>
     <%= f.submit "購入を確定する", class:"btn btn-success center-block" %>
 <% end %>

--- a/app/views/member/orders/_confirmation_button.html.erb
+++ b/app/views/member/orders/_confirmation_button.html.erb
@@ -1,10 +1,11 @@
 <!-- recieves order -->
 
-<%= form_for order, url: members_orders_path do |f| %>
+<%= form_with model: order, url: members_orders_path, local: true do |f| %>
     <%= f.hidden_field :postal_code %>
     <%= f.hidden_field :address %>
     <%= f.hidden_field :name %>
     <%= f.hidden_field :payment_method %>
     <%= f.hidden_field :billing_amount %>
+    <%= f.hidden_field :new_ship?, true %>
     <%= f.submit "購入を確定する", class:"btn btn-success center-block" %>
 <% end %>

--- a/app/views/member/orders/_confirmation_button.html.erb
+++ b/app/views/member/orders/_confirmation_button.html.erb
@@ -6,6 +6,6 @@
     <%= f.hidden_field :name %>
     <%= f.hidden_field :payment_method %>
     <%= f.hidden_field :billing_amount %>
-    <%= f.hidden_field :new_ship?, true %>
+    <%= f.hidden_field :new_ship?, value: "1" %>
     <%= f.submit "購入を確定する", class:"btn btn-success center-block" %>
 <% end %>

--- a/app/views/member/orders/confirm.html.erb
+++ b/app/views/member/orders/confirm.html.erb
@@ -24,7 +24,7 @@
         <td><%= "#{@order.postal_code} #{@order.address} \n #{@order.name}" %></td>
       </tr>
     </table>
-    <%= render 'member/orders/confirmation_button', order: @order %>
+    <%= render 'member/orders/confirmation_button', order: @order, new_ship: @new_ship %>
   </div>
 
 </div>

--- a/test/integration/member_order_interface_test.rb
+++ b/test/integration/member_order_interface_test.rb
@@ -81,7 +81,7 @@ class MemberOrderInterfaceTest < ActionDispatch::IntegrationTest
     assert_difference 'CartItem.count', -1 do #member1がcart_item1個の前提
       assert_difference 'Order.count', 1 do
         assert_difference 'OrderItem.count', 1 do
-          assert_difference 'Ship.count', 1 do
+          assert_no_difference 'Ship.count' do
             post members_orders_path, params: {order:{ postal_code: "7654321",
                                                    address: "大阪府高野飯",
                                                    name: "三五郎",
@@ -96,6 +96,25 @@ class MemberOrderInterfaceTest < ActionDispatch::IntegrationTest
     assert_equal new_order.order_items.count, 1
     follow_redirect!
     assert_select "h2", "ご購入ありがとうございました！"
+
+    #新しい配送先を作成した場合
+    CartItem.create(member: @member,
+                    item: items(:item1),
+                    amount: 2)
+    assert_difference 'CartItem.count', -1 do
+      assert_difference 'Order.count', 1 do
+        assert_difference 'OrderItem.count', 1 do
+          assert_difference 'Ship.count', 1 do
+            post members_orders_path, params: {order:{ postal_code: "7654321",
+                                                   address: "大阪府高野飯",
+                                                   name: "三五郎",
+                                                   billing_amount: 100,
+                                                   payment_method: "クレジットカード",
+                                                   new_ship?: true}}
+          end
+        end
+      end
+    end
   end
 
   test "index view" do

--- a/test/integration/member_order_interface_test.rb
+++ b/test/integration/member_order_interface_test.rb
@@ -45,7 +45,7 @@ class MemberOrderInterfaceTest < ActionDispatch::IntegrationTest
     new_order = assigns(:order)
     assert_equal new_order.address, @member.ships.first.address
     #配送先の追加を選択
-    assert_difference 'Ship.count', 1 do
+    assert_no_difference 'Ship.count' do
         post confirm_members_orders_path, params: {order:{ choice: "2",
                                                payment_method: "クレジットカード",
                                                ship_postal_code: "7654321",
@@ -81,11 +81,13 @@ class MemberOrderInterfaceTest < ActionDispatch::IntegrationTest
     assert_difference 'CartItem.count', -1 do #member1がcart_item1個の前提
       assert_difference 'Order.count', 1 do
         assert_difference 'OrderItem.count', 1 do
-          post members_orders_path, params: {order:{ postal_code: "7654321",
-                                                 address: "大阪府高野飯",
-                                                 name: "三五郎",
-                                                 billing_amount: 100,
-                                                 payment_method: "クレジットカード"}}
+          assert_difference 'Ship.count', 1 do
+            post members_orders_path, params: {order:{ postal_code: "7654321",
+                                                   address: "大阪府高野飯",
+                                                   name: "三五郎",
+                                                   billing_amount: 100,
+                                                   payment_method: "クレジットカード"}}
+          end
         end
       end
     end

--- a/test/integration/member_order_interface_test.rb
+++ b/test/integration/member_order_interface_test.rb
@@ -110,7 +110,7 @@ class MemberOrderInterfaceTest < ActionDispatch::IntegrationTest
                                                    name: "三五郎",
                                                    billing_amount: 100,
                                                    payment_method: "クレジットカード",
-                                                   new_ship?: true}}
+                                                   new_ship: true}}
           end
         end
       end


### PR DESCRIPTION
注文時、Shipが登録されたらすぐDBに保存される挙動を修正。
確認ボタンが押したあと、createアクションで保存されるように実装