### PR TITLE
Hotfix genred items

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,7 +1,8 @@
 class HomesController < ApplicationController
   def top
     @genres = Genre.all
-    Item.count > 3 ? @items = Item.all.sort_by{rand}.first(4) : @items = Item.take(1)
+    Item.saled_items.count > 3 ?
+    @items = Item.saled_items.all.sort_by{rand}.first(4) : @items = Item.saled_items.take(1)
   end
 
   def about

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,5 +1,6 @@
 class HomesController < ApplicationController
   def top
+    Item.check_valid_items
     @genres = Genre.all
     Item.saled_items.count > 3 ?
     @items = Item.saled_items.all.sort_by{rand}.first(4) : @items = Item.saled_items.take(1)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,7 +20,7 @@ class ItemsController < ApplicationController
 
   private
     def set_genres
-      @genres = Genre.all
+      @genres = Genre.where(is_valid: true)
     end
 
     def check_valid_items

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,8 +2,8 @@ class ItemsController < ApplicationController
   before_action :set_genres
 
   def index
-    @items = Item.saled_items().page(params[:page]).per(8).reverse_order
-    @count = Item.saled_items().count
+    @items = Item.saled_items.page(params[:page]).per(8).reverse_order
+    @count = Item.saled_items.count
   end
 
   def search

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,14 +2,14 @@ class ItemsController < ApplicationController
   before_action :set_genres
 
   def index
-    @items = Item.page(params[:page]).per(8).reverse_order
-    @count = Item.count
+    @items = Item.saled_items().page(params[:page]).per(8).reverse_order
+    @count = Item.saled_items().count
   end
 
   def search
     @genre = Genre.find(params[:id])
-    @items = @genre.items.page(params[:page]).per(8).reverse_order
-    @count = @genre.items.count
+    @items = saled_items(@genre).page(params[:page]).per(8).reverse_order
+    @count = saled_items(@genre).count
     render :index
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :set_genres
+  before_action :check_valid_items, only: [:index, :search] #毎度eachを回すのはあまり好ましくない
 
   def index
     @items = Item.saled_items.page(params[:page]).per(8).reverse_order
@@ -8,8 +9,8 @@ class ItemsController < ApplicationController
 
   def search
     @genre = Genre.find(params[:id])
-    @items = saled_items(@genre).page(params[:page]).per(8).reverse_order
-    @count = saled_items(@genre).count
+    @items = Item.saled_items(@genre).page(params[:page]).per(8).reverse_order
+    @count = Item.saled_items(@genre).count
     render :index
   end
 
@@ -21,4 +22,9 @@ class ItemsController < ApplicationController
     def set_genres
       @genres = Genre.all
     end
+
+    def check_valid_items
+        Item.check_valid_items
+    end
+
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -24,7 +24,4 @@ class Item < ApplicationRecord
       genre.blank? ? Item.where(is_saled: true) : genre.items.where(is_saled: true)
   end
 
-  def genre_valid_items
-  end
-
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,6 +11,11 @@ class Item < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
   validates :explanation, presence: true, length: { maximum: 255 }
   validates :price, presence: true
-  
+
   validates :is_saled, inclusion: [true, false]
+
+  def self.saled_items(genre = "")
+      genre.blank? ? Item.where(is_saled: true) : genre.items.where(is_saled: true)
+  end
+
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,8 +14,17 @@ class Item < ApplicationRecord
 
   validates :is_saled, inclusion: [true, false]
 
+  def self.check_valid_items #ジャンルが無効なら商品を「売り切れ」に
+      self.saled_items.each do |item|
+          item.update(is_saled: false) unless item.genre.is_valid
+      end
+  end
+
   def self.saled_items(genre = "")
       genre.blank? ? Item.where(is_saled: true) : genre.items.where(is_saled: true)
+  end
+
+  def genre_valid_items
   end
 
 end


### PR DESCRIPTION
販売停止中の商品がトップページ、一覧ページで表示されないよう修正
さらにジャンルが無効なら商品を販売停止にするように修正